### PR TITLE
fix: remove stray brackets from minor package name

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -148,7 +148,7 @@ function getOverrides(version = args.version): Record<string, string> {
       if (RELEASE_TAG === 'canary') {
         return [name, `npm:${packageName}${version ? `@${version}` : ''}`]
       } else if (RELEASE_TAG === 'canary-minor') {
-        return [name, `npm:${packageName}@${version ?? 'minor'}}`]
+        return [name, `npm:${packageName}@${version ?? 'minor'}`]
       } else {
         return [name, `${version ?? RELEASE_TAG}`]
       }


### PR DESCRIPTION
I followed the documentation of the Vue docs to install the canary version of the next minor here https://vuejs.org/about/releases via `npx install-vue@canary-minor`.

The generated overrides did not look right:

```json
"dependencies": {
    "vue": "npm:@vue/canary@3.20240715.0-minor.0}",
  }
"overrides": {
    "vue": "npm:@vue/canary@3.20240715.0-minor.0}",
    "@vue/compiler-core": "npm:@vue/compiler-core-canary@3.20240715.0-minor.0}",
    "@vue/compiler-dom": "npm:@vue/compiler-dom-canary@3.20240715.0-minor.0}",
    "@vue/compiler-sfc": "npm:@vue/compiler-sfc-canary@3.20240715.0-minor.0}",
    "@vue/compiler-ssr": "npm:@vue/compiler-ssr-canary@3.20240715.0-minor.0}",
    "@vue/reactivity": "npm:@vue/reactivity-canary@3.20240715.0-minor.0}",
    "@vue/reactivity-transform": "npm:@vue/reactivity-transform-canary@3.20240715.0-minor.0}",
    "@vue/runtime-core": "npm:@vue/runtime-core-canary@3.20240715.0-minor.0}",
    "@vue/runtime-dom": "npm:@vue/runtime-dom-canary@3.20240715.0-minor.0}",
    "@vue/server-renderer": "npm:@vue/server-renderer-canary@3.20240715.0-minor.0}",
    "@vue/shared": "npm:@vue/shared-canary@3.20240715.0-minor.0}",
}
```

This PR removes the trailing `}` bracket.